### PR TITLE
feat: improve the startup process of the MySQL container

### DIFF
--- a/cdc-observer.go
+++ b/cdc-observer.go
@@ -33,7 +33,10 @@ func NewCDCObserver(ctx context.Context, opt *Options) (*CDCObserver, error) {
 	if opt.EnableDocker {
 		observer.enableDocker = true
 		observer.containername = opt.ContainerName
-		dockerClient := NewDockerClient(observer.dbName)
+		dockerClient, err := NewDockerClient()
+		if err != nil {
+			return nil, err
+		}
 		observer.dockerClient = dockerClient
 	}
 	observer.containerPort = opt.ContainerPort
@@ -70,7 +73,7 @@ func (ob *CDCObserver) Start(ctx context.Context) error {
 
 func (ob *CDCObserver) Close(ctx context.Context) error {
 	if ob.enableDocker {
-		ob.dockerClient.StopAllContianer(ctx)
+		ob.dockerClient.StopAllContainers(ctx)
 	}
 	ob.river.Close()
 	return nil

--- a/docker-interaction_test.go
+++ b/docker-interaction_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestStartMySQLContainer(t *testing.T) {
-	dockerClient := DockerClient{}
+	dockerClient, _ := NewDockerClient()
 	ctx := context.Background()
-	dockerClient.StartMySQLContainer(ctx)
+	_ = dockerClient.StartMySQLContainer(ctx)
 }

--- a/example/main.go
+++ b/example/main.go
@@ -6,7 +6,7 @@ import (
 )
 
 func main() {
-	dockerClient := cdc.NewDockerClient("elliot_test_name")
+	dockerClient, _ := cdc.NewDockerClient()
 	ctx := context.Background()
-	dockerClient.StartMySQLContainer(ctx)
+	_ = dockerClient.StartMySQLContainer(ctx)
 }


### PR DESCRIPTION
What have I done:
1. Maintain a common configuration within cdc-observer. The MySQL container name is `cdc-observer-mysql`, the database name is `cdc-observer`, the user name is root, and the password is `cdc-observer-password`.No more user configuration required.
2. use `0` to let docker automatically choose a free port, avoiding port conflict.
3. Check if the container already exists. If the container already exists, start the old container. Otherwise, start a new container.

After that, we can start the container and directly create a corresponding Database instance to connect to the database in this container, without the user having to manually create the database.